### PR TITLE
Create subclass for Servicelevel for mapping JSON on Rate

### DIFF
--- a/Shippo/Rate.cs
+++ b/Shippo/Rate.cs
@@ -48,16 +48,17 @@ namespace Shippo {
 
         [JsonProperty(PropertyName = "zone")]
         public object Zone { get; set; }
+    }
 
-        public class ServiceLevel {
-            [JsonProperty (PropertyName = "name")]
-            public object Name { get; set; }
+    public class ServiceLevel
+    {
+        [JsonProperty(PropertyName = "name")]
+        public object Name { get; set; }
 
-            [JsonProperty (PropertyName = "token")]
-            public object Token { get; set; }
+        [JsonProperty(PropertyName = "token")]
+        public object Token { get; set; }
 
-            [JsonProperty (PropertyName = "terms")]
-            public object Terms { get; set; }
-        }
+        [JsonProperty(PropertyName = "terms")]
+        public object Terms { get; set; }
     }
 }

--- a/Shippo/Rate.cs
+++ b/Shippo/Rate.cs
@@ -35,7 +35,7 @@ namespace Shippo {
         public object ProviderImage200 { get; set; }
 
         [JsonProperty(PropertyName = "servicelevel")]
-        public object Servicelevel { get; set; }
+        public ServiceLevel Servicelevel { get; set; }
 
         [JsonProperty(PropertyName = "estimated_days")]
         public object EstimatedDays { get; set; }
@@ -49,5 +49,15 @@ namespace Shippo {
         [JsonProperty(PropertyName = "zone")]
         public object Zone { get; set; }
 
+        public class ServiceLevel {
+            [JsonProperty (PropertyName = "name")]
+            public object Name { get; set; }
+
+            [JsonProperty (PropertyName = "token")]
+            public object Token { get; set; }
+
+            [JsonProperty (PropertyName = "terms")]
+            public object Terms { get; set; }
+        }
     }
 }

--- a/Shippo/Shippo.nuspec
+++ b/Shippo/Shippo.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Shippo</id>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <title>Shippo client library</title>
     <authors>Shippo</authors>
     <owners>Shippo</owners>


### PR DESCRIPTION
We aren't correctly mapping the JSON being returned on `Servicelevel` in the Rate since the chance in v3 of the API.

This should allow the `Rate.Servicelevel` to correctly map